### PR TITLE
Mongofy event data

### DIFF
--- a/concertFinder/concertFinder/api.py
+++ b/concertFinder/concertFinder/api.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from ninja import NinjaAPI
+from concertFinder.mongo_setup import collection
 import requests
 import environ
 
@@ -8,39 +9,11 @@ api = NinjaAPI()
 env = environ.Env()
 environ.Env.read_env()
 
-YEAR_AGO_STR = (datetime.now() - timedelta(days=365)).isoformat()
-EVENT_API_DOMAIN = "https://rest.bandsintown.com/artists"
-DATE_RANGE = f"events"  # ?date={YEAR_AGO_STR}"
-
 
 @api.get("/events")
 def events(request, artist_name):
-    payload = {"app_id": env("APP_ID")}
-    r = requests.get(
-        f"{EVENT_API_DOMAIN}/{artist_name}/{DATE_RANGE}", params=payload
-    )  # consider switching to SeatGeek for tour name data
-    data = {"status": r.status_code, "events": []}
-    if r.status_code == 200:
-        for event in r.json():
-            show = {"past": False}  # default 'past' key to False
-            event_datetime = datetime.strptime(event["starts_at"], "%Y-%m-%dT%H:%M:%S")
-            if datetime.now() > event_datetime:
-                # show["past"] = True # implement feature with previous dates
-                continue
-
-            show["venue"] = event["venue"]
-            show["headliner"] = event["lineup"][0] if len(event["lineup"]) > 0 else ""
-            show["openers"] = ", ".join(event["lineup"][1:])
-            show["startsat"] = {}
-            show["startsat"]["detailed"] = event_datetime.strftime(
-                "%a %B %-d, %-I:%M %p"
-            )
-            show["startsat"]["day"] = event_datetime.strftime("%a")
-            show["startsat"]["month"] = event_datetime.strftime("%b")
-            show["startsat"]["date"] = event_datetime.strftime("%-d")
-            show["startsat"]["time"] = event_datetime.strftime("%-I:%M %p")
-            offers = event["offers"]
-            show["url"] = offers[0].get("url") if offers else ""
-            data["events"].append(show)
-
-    return data
+    response = {"status": 200, "events": []}
+    record = collection.find_one({"artist_name": artist_name})
+    if record:
+        response["events"] = record["events"]
+    return response

--- a/concertFinder/concertFinder/management/commands/import_mongo.py
+++ b/concertFinder/concertFinder/management/commands/import_mongo.py
@@ -1,0 +1,71 @@
+from django.core.management.base import BaseCommand, CommandError
+from datetime import datetime, timedelta
+
+from concertFinder.mongo_setup import collection
+import environ
+import requests
+
+env = environ.Env()
+environ.Env.read_env()
+
+MONGO_PASS = env("MONGO_PASS")
+SG_CLIENT_ID = env("SG_CLIENT_ID")
+SG_CLIENT_SECRET = env("SG_CLIENT_SECRET")
+BANDSINTOWN_APP_ID = env("BANDSINTOWN_APP_ID")
+
+SEATGEEK_API_URL = f"https://api.seatgeek.com/2/performers?client_id={SG_CLIENT_ID}&client_secret={SG_CLIENT_SECRET}&sort=score.desc&type=band&per_page=10"
+BANDSINTOWN_API_URL = "https://rest.bandsintown.com/artists/"
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        seatgeek_request = requests.get(SEATGEEK_API_URL)
+        seatgeek_request.raise_for_status()
+        top_artists = handle_sg_response(seatgeek_request.json())
+        print(top_artists)
+        populate_mongo_events(top_artists)
+
+
+def handle_sg_response(content):
+    artists = []
+    performers = content.get("performers")
+    for artist in performers:
+        artists.append(artist["name"])
+    return artists
+
+
+def populate_mongo_events(top_artists):
+    payload = {"app_id": BANDSINTOWN_APP_ID}
+    for artist in top_artists:
+        bandsintown_request = requests.get(
+            f"{BANDSINTOWN_API_URL}{artist}/events", params=payload
+        )
+        bandsintown_request.raise_for_status()
+        events_formatted = parse_events(bandsintown_request.json())
+        if events_formatted:
+            collection.update_one(
+                {"artist_name": artist},
+                {"$set": {"events": events_formatted}},
+                upsert=True,
+            )
+
+
+def parse_events(events):
+    formatted_events = []
+    for event in events:
+        show = {}
+        date = datetime.strptime(event["starts_at"], "%Y-%m-%dT%H:%M:%S")
+        show["venue"] = event["venue"]
+        show["headliner"] = event["lineup"][0] if len(event["lineup"]) > 0 else ""
+        show["openers"] = ", ".join(event["lineup"][1:])
+        show["startsat"] = {}
+        show["startsat"]["detailed"] = date.strftime("%a %B %-d, %-I:%M %p")
+        show["startsat"]["day"] = date.strftime("%a")
+        show["startsat"]["month"] = date.strftime("%b")
+        show["startsat"]["date"] = date.strftime("%-d")
+        show["startsat"]["time"] = date.strftime("%-I:%M %p")
+        offers = event["offers"]
+        show["url"] = offers[0].get("url") if offers else ""
+        formatted_events.append(show)
+
+    return formatted_events

--- a/concertFinder/concertFinder/mongo_setup.py
+++ b/concertFinder/concertFinder/mongo_setup.py
@@ -1,0 +1,11 @@
+from pymongo.mongo_client import MongoClient
+from pymongo.server_api import ServerApi
+import environ
+
+env = environ.Env()
+environ.Env.read_env()
+
+uri = f"mongodb+srv://adriansharpe148:{env('MONGO_PASS')}@cluster0.exyeuin.mongodb.net/?retryWrites=true&w=majority"
+client = MongoClient(uri, server_api=ServerApi("1"))
+db = client["gigmapr"]
+collection = db["events"]


### PR DESCRIPTION
This PR adds mongo support so that the app relies on a db populated by the bandsintown api rather than calling the API directly on search. I've also added a management command to fetch top artists (from Seatgeek) and populate the mongo db via bandsintown data. The app's `/events/` API endpoint has been modified to read from mongo atlas db.